### PR TITLE
specific werkzeug version to 2.x, it will incompatible when vesion >3.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ click==8.1.3
 pymavlink==2.4.37
 gevent==22.10.2
 Flask==2.2.3
+Werkzeug==2.2.2
 requests==2.28.2
 jsonschema==4.17.3
 flask-cors==3.0.10


### PR DESCRIPTION
Default version of werkzeug may be 3.x, and error will occur because
```
ImportError: cannot import name 'url_quote' from 'werkzeug.urls'
```
It could be solved by specific version installation ``` werkzeug>=2.2,<3 ```